### PR TITLE
Remove null bytes in adapter name

### DIFF
--- a/lib/odbc_adapter/registry.rb
+++ b/lib/odbc_adapter/registry.rb
@@ -11,7 +11,8 @@ module ODBCAdapter
     end
 
     def adapter_for(reported_name)
-      reported_name = reported_name.downcase.gsub(/\s/, '')
+      reported_name = reported_name.downcase.gsub(/\s/, '').delete("\0")
+
       found =
         dbs.detect do |pattern, adapter|
           adapter if reported_name =~ pattern


### PR DESCRIPTION
Null chars in the input string will mislead us to target adapter. Simply delete all null chars should work.